### PR TITLE
buildRustCrate: support rlib dependency type

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -23,7 +23,7 @@ let
             lib.strings.replaceStrings ["-"] ["_"] crateRenames.${dep.crateName}
           else
             extern;
-        in (if lib.any (x: x == "lib") dep.crateType then
+        in (if lib.any (x: x == "lib" || x == "rlib") dep.crateType then
            " --extern ${name}=${dep.lib}/lib/lib${extern}-${dep.metadata}.rlib"
          else
            " --extern ${name}=${dep.lib}/lib/lib${extern}-${dep.metadata}${stdenv.hostPlatform.extensions.sharedLibrary}")

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -1,17 +1,17 @@
 { lib, buildRustCrate, runCommand, writeTextFile, symlinkJoin, callPackage, releaseTools }:
 let
   mkCrate = args: let
-      p = {
-        crateName = "nixtestcrate";
-        version = "0.1.0";
-        authors = [ "Test <test@example.com>" ];
-      } // args;
-    in buildRustCrate p;
+    p = {
+      crateName = "nixtestcrate";
+      version = "0.1.0";
+      authors = [ "Test <test@example.com>" ];
+    } // args;
+  in buildRustCrate p;
 
-    mkFile = destination: text: writeTextFile {
-      name = "src";
-      destination = "/${destination}";
-      inherit text;
+  mkFile = destination: text: writeTextFile {
+    name = "src";
+    destination = "/${destination}";
+    inherit text;
   };
 
   mkBin = name: mkFile name ''

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -185,7 +185,20 @@ let
           "test tests_bar ... ok"
         ];
       };
-
+      linkAgainstRlibCrate = {
+        crateName = "foo";
+        src = mkFile  "src/main.rs" ''
+          extern crate somerlib;
+          fn main() {}
+        '';
+        dependencies = [
+          (mkCrate {
+            crateName = "somerlib";
+            type = [ "rlib" ];
+            src = mkLib "src/lib.rs";
+          })
+        ];
+      };
     };
     brotliCrates = (callPackage ./brotli-crates.nix {});
   in lib.mapAttrs (key: value: mkTest (value // lib.optionalAttrs (!value?crateName) { crateName = key; })) cases // {


### PR DESCRIPTION
This adds support for linking against `rlib` type crates. They are basically the same as `lib` crates for our purposes.