### PR TITLE
buildRustCrate: do not overlay OUT_PATH on src

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -137,16 +137,7 @@ in ''
      CRATENAME=$(echo ${crateName} | sed -e "s/\(.*\)-sys$/\U\1/")
      grep -P "^cargo:(?!(rustc-|warning=|rerun-if-changed=|rerun-if-env-changed))" target/build/${crateName}.opt \
        | sed -e "s/cargo:\([^=]*\)=\(.*\)/export DEP_$(echo $CRATENAME)_\U\1\E=\2/" > target/env
-
      set -e
-     if [[ -n "$(ls target/build/${crateName}.out)" ]]; then
-
-        if [[ -e "${libPath}" ]]; then
-           cp -r target/build/${crateName}.out/* $(dirname ${libPath}) #*/
-        else
-           cp -r target/build/${crateName}.out/* src #*/
-        fi
-     fi
   fi
   runHook postConfigure
 ''


### PR DESCRIPTION
Previously generated files would be dropped into the `src/` directory causing issues with crates creating files that already existed in the source dir.