### PR TITLE
pythonPackages.intreehooks: init at 1.0

### DIFF
--- a/pkgs/development/python-modules/intreehooks/default.nix
+++ b/pkgs/development/python-modules/intreehooks/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytoml
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "intreehooks";
+  version = "1.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "87e600d3b16b97ed219c078681260639e77ef5a17c0e0dbdd5a302f99b4e34e1";
+  };
+
+  propagatedBuildInputs = [ pytoml ];
+
+  checkInputs = [ pytest ];
+
+  meta = {
+    description = "Load a PEP 517 backend from inside the source tree";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.fridh ];
+    homepage = https://github.com/takluyver/intreehooks;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2499,6 +2499,8 @@ in {
 
   iniparse = callPackage ../development/python-modules/iniparse { };
 
+  intreehooks = callPackage ../development/python-modules/intreehooks { };
+
   i3-py = callPackage ../development/python-modules/i3-py { };
 
   JayDeBeApi = callPackage ../development/python-modules/JayDeBeApi {};


### PR DESCRIPTION
Cherry-pick `intreehooks` pythnon module which is needed for building `poetry` via `poetry2nix`