### PR TITLE
Backported fix for calling buildLayeredImage with large number of derivations

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -234,4 +234,13 @@ rec {
     contents = [ pkgs.hello ];
   };
 
+  # 15. Create a layered image with only 2 layers
+  two-layered-image = pkgs.dockerTools.buildLayeredImage {
+    name = "two-layered-image";
+    tag = "latest";
+    config.Cmd = [ "${pkgs.hello}/bin/hello" ];
+    contents = [ pkgs.bash pkgs.hello ];
+    maxLayers = 2;
+  };
+
 }

--- a/pkgs/build-support/docker/store-path-to-layer.sh
+++ b/pkgs/build-support/docker/store-path-to-layer.sh
@@ -5,11 +5,8 @@ set -eu
 layerNumber=$1
 shift
 
-storePath="$1"
-shift
-
 layerPath="./layers/$layerNumber"
-echo "Creating layer #$layerNumber for $storePath"
+echo "Creating layer #$layerNumber for $@"
 
 mkdir -p "$layerPath"
 
@@ -34,14 +31,16 @@ tar -cf "$layerPath/layer.tar"  \
 # the relative nix store path, tar will ignore changes
 # to /nix/store. In order to create the correct structure
 # in the tar file, we transform the relative nix store
-# path to the absolute store path
-n=$(basename "$storePath")
-tar -C /nix/store -rpf "$layerPath/layer.tar" \
-    --hard-dereference --sort=name \
-    --mtime="@$SOURCE_DATE_EPOCH" \
-    --owner=0 --group=0 \
-    --transform="s,$n,/nix/store/$n," \
-    $n
+# path to the absolute store path.
+for storePath in "$@"; do
+  n=$(basename "$storePath")
+  tar -C /nix/store -rpf "$layerPath/layer.tar" \
+      --hard-dereference --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      --owner=0 --group=0 \
+      --transform="s,$n,/nix/store/$n," \
+      $n
+done
 
 # Compute a checksum of the tarball.
 tarhash=$(tarsum < $layerPath/layer.tar)


### PR DESCRIPTION
cherry-picked from: https://github.com/NixOS/nixpkgs/commit/3b65b3f6d637c6576cd9a0fe954aced5aa70de12

A recent change to buildLayeredImage (that we also backported) caused a
regression on derivations with a lot of dependencies. Technical details
are in the commit message.

This used to work when packaging Rust applications since they do not
have so many dependencies when compiled; however caused issues for
Python derivations.

I tried this locally on an image which demonstrated the issue, and it
seems to work fine.